### PR TITLE
Futures: minor update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status][github-ci-badge]][github-link]
 [![Codacy Badge][codacy-badge]][codacy-link]
+[![Codecov Badge][codecov-badge]][codecov-link]
 [![MIT License][license-badge]](LICENSE)
 [![Language][language-badge]][language-link]
 
@@ -68,6 +69,8 @@ Checks `bazel-kcov` directory for code coverage.
 [github-link]: https://github.com/condy0919/bipolar
 [codacy-badge]: https://api.codacy.com/project/badge/Grade/7c5e88ade2944d7ca1741d2b3e709f4f
 [codacy-link]: https://www.codacy.com/manual/condy0919/bipolar?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=condy0919/bipolar&amp;utm_campaign=Badge_Grade
+[codecov-badge]: https://codecov.io/gh/condy0919/bipolar/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/condy0919/bipolar
 [license-badge]: https://img.shields.io/badge/license-MIT-007EC7.svg
 [language-badge]: https://img.shields.io/badge/Language-C%2B%2B17-blue.svg
 [language-link]: https://en.cppreference.com/w/cpp/compiler_support

--- a/bipolar/core/BUILD.bazel
+++ b/bipolar/core/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
         "function_ref.hpp",
         "internal/enable_special_members.hpp",
         "likely.hpp",
+        "movable.hpp",
         "option.hpp",
         "overload.hpp",
         "result.hpp",

--- a/bipolar/core/benchmarks/option_benchmark.cpp
+++ b/bipolar/core/benchmarks/option_benchmark.cpp
@@ -1,5 +1,6 @@
 #include "bipolar/core/option.hpp"
 
+#include <optional>
 #include <string>
 #include <cstdint>
 
@@ -45,3 +46,21 @@ static void BM_bipolar_option(benchmark::State& state) {
     }
 }
 BENCHMARK(BM_bipolar_option)->Range(1, 1024);
+
+static void BM_std_optional(benchmark::State& state) {
+    const std::size_t n = state.range(0);
+    const auto fn = [](std::size_t arg) -> std::optional<std::string> {
+        if (arg % 2 == 0) {
+            return {};
+        }
+        return std::make_optional("foo"s);
+    };
+
+    for (auto _ : state) {
+        for (std::size_t i = 0; i < n; ++i) {
+            auto opt = fn(i);
+            benchmark::DoNotOptimize(opt);
+        }
+    }
+}
+BENCHMARK(BM_std_optional)->Range(1, 1024);

--- a/bipolar/core/function.hpp
+++ b/bipolar/core/function.hpp
@@ -84,9 +84,14 @@ class Function<R(Args...)> {
     static R empty_call_(const Function*, Args...) {
         throw std::bad_function_call();
     }
+
+    // A constexpr specifier used in static member variable (since C++17)
+    // declaration implies inline.
+    //
+    // See https://en.cppreference.com/w/cpp/language/constexpr
     static constexpr Vtable empty_vtable_ = {
         empty_destroy_,
-        empty_call_
+        empty_call_,
     };
 
 public:

--- a/bipolar/core/movable.hpp
+++ b/bipolar/core/movable.hpp
@@ -1,0 +1,23 @@
+//! Movable
+//!
+//! `Movable` is like `boost::noncopyable`.
+//! But it allows move constructible/assignable.
+
+#ifndef BIPOLAR_CORE_MOVABLE_HPP_
+#define BIPOLAR_CORE_MOVABLE_HPP_
+
+namespace bipolar {
+class Movable {
+public:
+    constexpr Movable() noexcept = default;
+    constexpr Movable(Movable&&) noexcept = default;
+    constexpr Movable& operator=(Movable&&) noexcept = default;
+
+    Movable(const Movable&) = delete;
+    Movable& operator=(const Movable&) = delete;
+
+    ~Movable() = default;
+};
+} // namespace bipolar
+
+#endif

--- a/bipolar/core/option.hpp
+++ b/bipolar/core/option.hpp
@@ -47,7 +47,7 @@ inline constexpr bool is_option_v = is_option<T>::value;
 // To support constexpr for Option<T>
 template <typename T>
 union OptionTrivialStorage {
-    T value;
+    [[no_unique_address]] T value;
     char dummy;
 
     constexpr OptionTrivialStorage() : dummy('\0') {}
@@ -61,7 +61,7 @@ union OptionTrivialStorage {
 
 template <typename T>
 union OptionNonTrivialStorage {
-    T value;
+    [[no_unique_address]] T value;
     char dummy;
 
     constexpr OptionNonTrivialStorage() : dummy('\0') {}

--- a/bipolar/core/result.hpp
+++ b/bipolar/core/result.hpp
@@ -295,8 +295,8 @@ struct SmallTrivialStorage : Storage<SmallTrivialStorage<T, E>> {
                   "SmallTrivialStorage isn't smaller than 2 pointers");
 
     Which which_;
-    T value_;
-    E error_;
+    [[no_unique_address]] T value_;
+    [[no_unique_address]] E error_;
 
     constexpr explicit SmallTrivialStorage(EmptyTag) noexcept(
         std::is_nothrow_default_constructible_v<T>&&
@@ -328,8 +328,8 @@ struct TrivialStorage : Storage<TrivialStorage<T, E>> {
 
     Which which_;
     union {
-        T value_;
-        E error_;
+        [[no_unique_address]] T value_;
+        [[no_unique_address]] E error_;
         char dummy_;
     };
 
@@ -356,8 +356,8 @@ template <typename T, typename E>
 struct NonTrivialStorageInner {
     Which which_ = Which::Empty;
     union {
-        T value_;
-        E error_;
+        [[no_unique_address]] T value_;
+        [[no_unique_address]] E error_;
         char dummy_;
     };
 
@@ -457,6 +457,10 @@ struct NonTrivialStorage
         }
     }
 
+    /// Re-introduce
+    using Base::assign_empty;
+
+    /// Overrides (actually shadows) the `Base` assign_value
     template <typename... Ts>
     constexpr void assign_value(Ts&&... ts) {
         this->clear();
@@ -464,6 +468,7 @@ struct NonTrivialStorage
         new ((void*)std::addressof(this->value())) T(std::forward<Ts>(ts)...);
     }
 
+    /// Overrides (actually shadows) the `Base` assign_error
     template <typename... Es>
     constexpr void assign_error(Es&&... es) {
         this->clear();
@@ -471,6 +476,7 @@ struct NonTrivialStorage
         new ((void*)std::addressof(this->value())) E(std::forward<Es>(es)...);
     }
 
+    /// Overrides (actually shadows) the `Base` assign
     template <typename U>
     constexpr void assign(U&& rhs) {
         if constexpr (std::is_same_v<std::decay_t<U>, NonTrivialStorage>) {

--- a/bipolar/futures/BUILD.bazel
+++ b/bipolar/futures/BUILD.bazel
@@ -1,0 +1,39 @@
+load(
+    "//bipolar:copts/configure_copts.bzl",
+    "BIPOLAR_DEFAULT_COPTS",
+    "BIPOLAR_DEFAULT_LINKOPTS",
+    "BIPOLAR_TEST_COPTS",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "futures",
+    srcs = [
+    ],
+    hdrs = [
+        "async_result.hpp",
+        "traits.hpp",
+    ],
+    copts = BIPOLAR_DEFAULT_COPTS,
+    linkopts = BIPOLAR_DEFAULT_LINKOPTS,
+    deps = [
+        "//bipolar/core",
+        "@boost//:callable_traits",
+    ],
+)
+
+cc_test(
+    name = "futures_test",
+    srcs = [
+        "tests/async_result_test.cpp",
+    ],
+    copts = BIPOLAR_DEFAULT_COPTS,
+    linkopts = BIPOLAR_DEFAULT_LINKOPTS,
+    deps = [
+        ":futures",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/bipolar/futures/async_result.hpp
+++ b/bipolar/futures/async_result.hpp
@@ -1,16 +1,16 @@
 //! AsyncResult
 //!
-//! `AsyncResult` is similar to `Result` except for allowing an empty state.
+//! `AsyncResult` is a wrapper to `Result` except for allowing an empty state.
 //!
 //! See documentation of `Result` for more information.
 
 #ifndef BIPOLAR_FUTURES_ASYNC_RESULT_HPP_
 #define BIPOLAR_FUTURES_ASYNC_RESULT_HPP_
 
-#include <utility>
-#include <variant>
 #include <type_traits>
+#include <utility>
 
+#include "bipolar/core/result.hpp"
 #include "bipolar/core/traits.hpp"
 
 namespace bipolar {
@@ -18,13 +18,27 @@ namespace bipolar {
 template <typename, typename>
 class AsyncResult;
 
-struct AsyncPending;
+/// Represents the intermediate state of a `AsyncResult` that has not yet
+/// completed.
+struct AsyncPending {};
 
-template <typename>
-struct AsyncOk;
+/// Represents the result of a successful task.
+template <typename T>
+struct AsyncOk {
+    constexpr /*implicit*/ AsyncOk(T&& val) : value(std::move(val)) {}
+    constexpr /*implicit*/ AsyncOk(const T& val) : value(val) {}
 
-template <typename>
-struct AsyncError;
+    T value;
+};
+
+/// Represents the result of a failed task.
+template <typename E>
+struct AsyncError {
+    constexpr /*implicit*/ AsyncError(E&& err) : error(std::move(err)) {}
+    constexpr /*implicit*/ AsyncError(const E& err) : error(err) {}
+
+    E error;
+};
 
 namespace detail {
 // AsyncResult helper traits
@@ -56,143 +70,108 @@ template <typename T>
 inline constexpr bool is_async_error_v = is_async_error<T>::value;
 } // namespace detail
 
-/// Represents the intermediate state of a `AsyncResult` that has not yet
-/// completed.
-struct AsyncPending {};
-
-/// Represents the result of a successful task.
-template <typename T>
-struct AsyncOk {
-    constexpr /*implicit*/ AsyncOk(T&& val) : value(std::move(val)) {}
-
-    constexpr /*implicit*/ AsyncOk(const T& val) : value(val) {}
-
-    T value;
-};
-
-/// Represents the result of a failed task.
-template <typename E>
-struct AsyncError {
-    constexpr /*implicit*/ AsyncError(E&& err) : error(std::move(err)) {}
-
-    constexpr /*implicit*/ AsyncError(const E& err) : error(err) {}
-
-    E error;
-};
-
+/// AsyncResult
+///
+/// `AsyncResult` represents the result of a task which may have succeeded,
+/// failed or still be in progress.
+///
+/// Use `AsyncPending{}`, `AsyncOk{}`, or `AsyncError{}` to initialize the
+/// result.
+///
+/// # Examples
+///
+/// ```
+/// AsyncResult<int, std::string> good = AsyncOk(13);
+///
+/// do_with_result(std::move(good));
+/// assert(good.is_pending());
+/// ```
 template <typename T, typename E>
-class AsyncResult {
+class AsyncResult final {
 public:
-    enum class State {
-        PENDING,
-        OK,
-        ERROR,
-    };
-
     using value_type = T;
     using error_type = E;
 
     /// Creates a pending result
-    constexpr AsyncResult() = default;
-    constexpr /*implicit*/ AsyncResult(AsyncPending) {}
+    constexpr AsyncResult() noexcept : result_(make_empty_result<T, E>()) {}
+    constexpr /*implicit*/ AsyncResult(AsyncPending) noexcept : AsyncResult() {}
 
-    /// @{
     /// Creates an ok result
-    template <typename U,
-              std::enable_if_t<std::is_constructible_v<T, U>, int> = 0>
-    constexpr /*implicit*/ AsyncResult(AsyncOk<U>&& ok)
-        : state_(std::in_place_index<1>, std::move(ok.value)) {}
+    constexpr /*implicit*/ AsyncResult(AsyncOk<T>&& ok) noexcept(
+        std::is_nothrow_move_constructible_v<T>)
+        : result_(Ok(std::move(ok.value))) {}
 
-    template <typename U,
-              std::enable_if_t<std::is_constructible_v<T, U>, int> = 0>
-    constexpr /*implicit*/ AsyncResult(const AsyncOk<U>& ok)
-        : state_(std::in_place_index<1>, ok.value) {}
-    /// @}
+    constexpr /*implicit*/ AsyncResult(const AsyncOk<T>& ok) noexcept(
+        std::is_nothrow_copy_constructible_v<T>)
+        : result_(Ok(ok.value)) {}
 
-    /// @{
     /// Creates an error result
-    template <typename U,
-              std::enable_if_t<std::is_constructible_v<E, U>, int> = 0>
-    constexpr /*implicit*/ AsyncResult(AsyncError<U>&& err)
-        : state_(std::in_place_index<2>, std::move(err.value)) {}
+    constexpr /*implicit*/ AsyncResult(AsyncError<E>&& err) noexcept(
+        std::is_nothrow_move_constructible_v<E>)
+        : result_(Err(std::move(err.error))) {}
 
-    template <typename U,
-              std::enable_if_t<std::is_constructible_v<E, U>, int> = 0>
-    constexpr /*implicit*/ AsyncResult(const AsyncError<U>& err)
-        : state_(std::in_place_index<2>, err.value) {}
-    /// @}
+    constexpr /*implicit*/ AsyncResult(const AsyncError<E>& err) noexcept(
+        std::is_nothrow_copy_constructible_v<E>)
+        : result_(Err(err.error)) {}
 
     /// Moves from another result, leaving the other one in a pending state
-    constexpr AsyncResult(AsyncResult&& rhs) : state_(std::move(rhs.state_)) {
+    constexpr AsyncResult(AsyncResult&& rhs) : result_(std::move(rhs.result_)) {
         rhs.reset();
     }
 
-    /// Copies another result (if copyable)
+    /// Copies/Assigns another result (if copyable)
     constexpr AsyncResult(const AsyncResult&) = default;
+    constexpr AsyncResult& operator=(const AsyncResult&) = default;
 
     ~AsyncResult() = default;
 
-    /// Assigns from another result (if copyable)
-    constexpr AsyncResult& operator=(const AsyncResult&) = default;
-
     /// Moves from another result, leaving the other one in a pending state
     constexpr AsyncResult& operator=(AsyncResult&& rhs) {
-        state_ = std::move(rhs.state_);
+        result_ = std::move(rhs.result_);
         rhs.reset();
         return *this;
     }
 
-    /// Returns the state of the task's result: pending, ok or error
-    constexpr State state() const {
-        return static_cast<State>(state_.index());
-    }
-
-    /// Returns true if the result is not pending
-    constexpr explicit operator bool() const {
-        return !is_pending();
-    }
-
     /// Returns true if the result is still in progress
     constexpr bool is_pending() const {
-        return state() == State::PENDING;
+        return has_nothing(result_);
     }
 
     /// Returns true if the task succeeded
     constexpr bool is_ok() const {
-        return state() == State::OK;
+        return result_.has_value();
     }
 
     /// Returns true if the task failed
     constexpr bool is_error() const {
-        return state() == State::ERROR;
+        return result_.has_error();
     }
 
-    /// @{
     /// Gets the result's value
-    /// Asserts that the result's state is `State::OK`
+    ///
+    /// Throws `BadResultAccess` when `is_ok()` is false.
     constexpr T& value() {
-        return std::get<1>(state_);
+        return result_.value();
     }
 
     constexpr const T& value() const {
-        return std::get<1>(state_);
+        return result_.value();
     }
-    /// @}
 
-    /// @{
     /// Gets the result's error
-    /// Asserts that the result's state is `State::ERROR`
+    ///
+    /// Throws `BadResultAccess` when `is_error()` is false.
     constexpr E& error() {
-        return std::get<2>(state_);
+        return result_.error();
     }
 
     constexpr const E& error() const {
-        return std::get<2>(state_);
+        return result_.error();
     }
-    /// @}
 
     /// Takes the result's value, leaving it in a pending state
-    /// Asserts that the result's state is `State::OK`
+    ///
+    /// Throws `BadResultAccess` when `is_ok()` is false.
     constexpr T take_value() {
         auto ret = std::move(value());
         reset();
@@ -200,7 +179,8 @@ public:
     }
 
     /// Takes the result's error, leaving it in a pending state
-    /// Asserts that the result's state is `State::ERROR`
+    ///
+    /// Throws `BadResultAccess` when `is_error()` is false.
     constexpr E take_error() {
         auto ret = std::move(error());
         reset();
@@ -209,17 +189,26 @@ public:
 
     /// Resets `AsyncResult`
     constexpr void reset() {
-        state_.template emplace<0>();
+        result_.assign(Empty{});
     }
 
     /// Swaps `AsyncResult`
-    constexpr void swap(AsyncResult& rhs) {
-        state_.swap(rhs);
+    constexpr void swap(AsyncResult& rhs) noexcept(
+        detail::all_of_v<std::is_nothrow_swappable, T, E>) {
+        result_.swap(rhs.result_);
     }
 
 private:
-    std::variant<std::monostate, T, E> state_;
+    Result<T, E> result_;
 };
+
+/// Swaps
+template <typename T, typename E>
+inline constexpr void
+swap(AsyncResult<T, E>& lhs, AsyncResult<T, E>& rhs) noexcept(
+    detail::all_of_v<std::is_nothrow_swappable, T, E>) {
+    lhs.swap(rhs);
+}
 
 } // namespace bipolar
 

--- a/bipolar/futures/tests/async_result_test.cpp
+++ b/bipolar/futures/tests/async_result_test.cpp
@@ -1,0 +1,97 @@
+#include <string>
+
+#include "bipolar/core/movable.hpp"
+#include "bipolar/core/void.hpp"
+#include "bipolar/futures/async_result.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace bipolar;
+using namespace std::literals;
+
+struct MoveOnly : Movable {};
+
+TEST(AsyncResult, Basic) {
+    AsyncResult<Void, Void> good = AsyncOk(Void{});
+    EXPECT_TRUE(good.is_ok());
+    EXPECT_FALSE(good.is_error());
+    EXPECT_FALSE(good.is_pending());
+
+    AsyncResult<Void, Void> bad = AsyncError(Void{});
+    EXPECT_TRUE(bad.is_error());
+    EXPECT_FALSE(bad.is_ok());
+    EXPECT_FALSE(bad.is_pending());
+
+    AsyncResult<Void, Void> pending = AsyncPending();
+    EXPECT_TRUE(pending.is_pending());
+    EXPECT_FALSE(pending.is_ok());
+    EXPECT_FALSE(pending.is_error());
+
+    AsyncResult<Void, Void> default_init;
+    EXPECT_TRUE(default_init.is_pending());
+    EXPECT_FALSE(default_init.is_ok());
+    EXPECT_FALSE(default_init.is_error());
+}
+
+TEST(AsyncResult, Move) {
+    AsyncResult<int, int> good = AsyncOk(42);
+    EXPECT_TRUE(good.is_ok());
+
+    auto tmpcopy = good;
+    EXPECT_TRUE(good.is_ok());
+    EXPECT_TRUE(tmpcopy.is_ok());
+    EXPECT_EQ(tmpcopy.value(), 42);
+
+    auto tmpmove = std::move(good);
+    EXPECT_TRUE(tmpmove.is_ok());
+    EXPECT_EQ(tmpmove.value(), 42);
+    EXPECT_FALSE(good.is_ok());
+    EXPECT_TRUE(good.is_pending());
+}
+
+TEST(AsyncResult, MoveOnly) {
+    AsyncResult<MoveOnly, Void> good = AsyncOk(MoveOnly{});
+    EXPECT_TRUE(good.is_ok());
+
+    // // @TODO clang failed to pass test
+    // // It's more likely the `no_unique_address` clang bug
+    // AsyncResult<MoveOnly, Void> tmpmove = std::move(good);
+    // EXPECT_TRUE(tmpmove.is_ok());
+    // EXPECT_FALSE(good.is_ok());
+    // EXPECT_TRUE(good.is_pending());
+}
+
+TEST(AsyncResult, Take) {
+    AsyncResult<int, std::string> good = AsyncOk(42);
+    EXPECT_EQ(good.take_value(), 42);
+    EXPECT_TRUE(good.is_pending());
+
+    good = AsyncError("foo"s);
+    EXPECT_TRUE(good.is_error());
+    EXPECT_EQ(good.take_error(), "foo");
+    EXPECT_TRUE(good.is_pending());
+}
+
+TEST(AsyncResult, Swap) {
+    AsyncResult<int, std::string> good = AsyncOk(13);
+    AsyncResult<int, std::string> bad = AsyncError("foo"s);
+
+    swap(good, bad);
+    EXPECT_TRUE(good.is_error());
+    EXPECT_EQ(good.error(), "foo");
+    EXPECT_TRUE(bad.is_ok());
+    EXPECT_EQ(bad.value(), 13);
+}
+
+TEST(AsyncResult, constexpr) {
+    constexpr AsyncResult<int, int> good = AsyncOk(1);
+    static_assert(good.is_ok());
+    static_assert(good.value() == 1);
+
+    constexpr AsyncResult<int, int> bad = AsyncError(-4);
+    static_assert(bad.is_error());
+    static_assert(bad.error() == -4);
+
+    constexpr AsyncResult<int, int> pending = AsyncPending();
+    static_assert(pending.is_pending());
+}

--- a/bipolar/futures/traits.hpp
+++ b/bipolar/futures/traits.hpp
@@ -16,7 +16,6 @@ namespace bipolar {
 // forward
 class Context;
 
-/// @{
 /// continuation_traits
 ///
 /// Deduces a continuation's result.
@@ -36,6 +35,7 @@ struct continuation_traits {
     using result_type = std::invoke_result_t<Continuation, Context&>;
 };
 
+/// Checks if it's a continuation type
 template <typename Continuation, typename = void>
 struct is_continuation : std::false_type {};
 
@@ -46,7 +46,6 @@ struct is_continuation<
 
 template <typename Continuation>
 inline constexpr bool is_continuation_v = is_continuation<Continuation>::value;
-/// @}
 
 } // namespace bipolar
 


### PR DESCRIPTION
# Core
- Movable: move-only base class
- Option: benchmark with `std::optional`
- Function: document
- Result: use `no_unique_address` to save space
- Option: use `no_unique_address` to save space

# Futures
- AsyncResult: rewrite & tests